### PR TITLE
Update action to new versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,10 +58,10 @@ runs:
   steps:
     # actions/checkout of the repo is used by both targets
     # (target-notifications, target-build-status).
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: Gottox/irc-message-action
         ref: v2.1.1


### PR DESCRIPTION
See <https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/>.
